### PR TITLE
fix(front): remove hardcoded values in creating the project

### DIFF
--- a/frontend/src/components/projectModale.tsx
+++ b/frontend/src/components/projectModale.tsx
@@ -16,7 +16,7 @@ export default function ProjectModal(props) {
     const { t } = useTranslation()
     const { updateProjects, setCurrentProject, updateProjectSheetData } = useMainContext();
     const [open, setOpen] = useState(false);
-    const [projectData, setProjectData] = useState<ProjectBase>({ name: '', protocol: '', creation_date: '', acquisition_framework: '', targeted_species: '', owner_id: 1, contact_id: 1 });
+    const [projectData, setProjectData] = useState<ProjectBase>({ name: '', protocol: '', creation_date: '', acquisition_framework: '', targeted_species: ''});
     const [startDate, setStartDate] = useState<Date | null>(null);
     const [endDate, setEndDate] = useState<Date | null>(null);
     const protocoles = ["Protocole A", "Protocole B", "Protocole C"];
@@ -46,7 +46,7 @@ export default function ProjectModal(props) {
 
     const handleClose = () => {
         setOpen(false);
-        setProjectData({ name: '', protocol: '', creation_date: '', acquisition_framework: '', targeted_species: '', owner_id: 1, contact_id: 1 });
+        setProjectData({ name: '', protocol: '', creation_date: '', acquisition_framework: '', targeted_species: ''});
         setStartDate(null);
         setEndDate(null);
     };


### PR DESCRIPTION
When the database is empty, it is impossible to create a project from home page.
It is because the front was sending `owner_id` and `contact_id` hardcoded values (1) in the POST request to create a project*

Related to #8 