### PR TITLE
fix(build): change minio command for health

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -137,7 +137,7 @@ services:
     volumes:
       - minio_data:/data
     healthcheck:      
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]      
+      test: ["CMD", "mc", "ready", "local"]      
       interval: 30s      
       timeout: 20s      
       retries: 3


### PR DESCRIPTION
Since the last version of minio, they changed the image from which minio image is built resulting in the absence of `curl`.

The healthcheck does not work anymore so this PR falls back to a better healthcheck with the following command : `mc ready local`
